### PR TITLE
Set encrypted_databag_secret in settings

### DIFF
--- a/ChefEncryptedDataBag.py
+++ b/ChefEncryptedDataBag.py
@@ -16,8 +16,8 @@ class ProcessDataBagItemMixin(object):
 
         # Read data_bag_key
         if not os.path.exists(secret_file):
-          sublime.error_message("data_bag_key not found:\n%s" % secret_file)
-          return
+          settings = sublime.load_settings("ChefEncryptedDataBag.sublime-settings")
+          secret_file = settings.get("encrypted_databag_secret", "encrypted_databag_secret")
         with open(secret_file) as f:
           secret = f.read()
 

--- a/ChefEncryptedDataBag.sublime-settings
+++ b/ChefEncryptedDataBag.sublime-settings
@@ -1,4 +1,6 @@
 {
   // Ruby executable path
-  // "ruby": "/Users/you/.anyenv/envs/rbenv/shims/ruby"
+  // "ruby": "/Users/you/.anyenv/envs/rbenv/shims/ruby",
+  // Path to encrypted data bag secret
+  // "encrypted_databag_secret": "/Users/you/.chef/encrypted_data_bag_secret"
 }

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ To see default settings, open menu item `[Sublime Text 2/3]-[Preferences]-[Packa
 2. Open encrypted/plain data bag item (JSON).
 3. Open command palette (`command + shift + p`) and run `Chef: Encrypt/Decrypt data bag item`
 
+Alternatively: 
+
+1. Set encrypted_databag_secret in your Settings to point to your data bag secret.
+2. Open command palette (`command + shift + p`) and run `Chef: Encrypt/Decrypt data bag item
+
 # License
 
 MIT License.


### PR DESCRIPTION
Added an alternative workflow, by which you can set the path to the encrypted_databag_secret in your settings and use it to decrypt/encrypt data bags. See README for additional workflow. 
